### PR TITLE
Slip Balancing

### DIFF
--- a/code/modules/clothing/shoes/f13.dm
+++ b/code/modules/clothing/shoes/f13.dm
@@ -75,7 +75,6 @@
 	icon_state = "military"
 	item_state = "military"
 	permeability_coefficient = 0.05
-	clothing_flags = NOSLIP
 	armor = list(melee = 10, bullet = 10, laser = 0, energy = 0, bomb = 10, bio = 0, rad = 0, fire = 10, acid = 0)
 	strip_delay = 40
 	resistance_flags = NONE
@@ -130,7 +129,6 @@
 	item_state = "legion-pelt"
 	cold_protection = FEET
 	min_cold_protection_temperature = SHOES_MIN_TEMP_PROTECT
-	clothing_flags = NOSLIP
 
 /obj/item/clothing/shoes/f13/military/plated
 	name = "plated war boots"
@@ -183,8 +181,7 @@
 	min_cold_protection_temperature = SHOES_MIN_TEMP_PROTECT
 	heat_protection = FEET
 	max_heat_protection_temperature = SHOES_MAX_TEMP_PROTECT
-	clothing_flags = NOSLIP
-
+	
 /obj/item/clothing/shoes/f13/miner
 	name = "mining boots"
 	desc = "Heavy-duty work boots with steel-reinforced toes and some fluffy wool for extra warmth."


### PR DESCRIPTION


## About The Pull Request
Removes the noslip variable from legions boots to balance the fact that you can slip ncr but not them.

## Why It's Good For The Game

Balance.

## Changelog
:cl:
Removed Noslip variable from legions boots.
/:cl:

